### PR TITLE
Hide subtasks from main list

### DIFF
--- a/www/assets/js/modules/app.js
+++ b/www/assets/js/modules/app.js
@@ -369,13 +369,14 @@ const renderTasks = async () => {
         // Add active tasks
         activeTopLevelTasks.forEach(task => {
             const taskElement = ui.createTaskElement(
-                task, 
+                task,
                 0,
                 tasks.toggleTaskCompletion,
                 tasks.deleteTask,
                 promptForSubtask,
                 tasks.toggleTaskSticky,
-                focusOnTask
+                focusOnTask,
+                false
             );
             ui.domElements.activeTaskList.appendChild(taskElement);
         });
@@ -383,13 +384,14 @@ const renderTasks = async () => {
         // Add completed tasks
         completedTopLevelTasks.forEach(task => {
             const taskElement = ui.createTaskElement(
-                task, 
+                task,
                 0,
                 tasks.toggleTaskCompletion,
                 tasks.deleteTask,
                 promptForSubtask,
                 tasks.toggleTaskSticky,
-                focusOnTask
+                focusOnTask,
+                false
             );
             ui.domElements.completedTaskList.appendChild(taskElement);
         });

--- a/www/assets/js/modules/ui.js
+++ b/www/assets/js/modules/ui.js
@@ -53,7 +53,16 @@ export const toggleSubtaskSection = (taskId, taskElement) => {
 };
 
 // Create HTML for a task item
-export const createTaskElement = (task, level = 0, onCheckboxChange, onDelete, onAddSubtask, onToggleSticky, onTaskClick) => {
+export const createTaskElement = (
+    task,
+    level = 0,
+    onCheckboxChange,
+    onDelete,
+    onAddSubtask,
+    onToggleSticky,
+    onTaskClick,
+    showSubtasks = true
+) => {
     const li = document.createElement('li');
     li.dataset.id = task.id;
     li.dataset.level = level;
@@ -186,8 +195,8 @@ export const createTaskElement = (task, level = 0, onCheckboxChange, onDelete, o
     // Add task row to the list item
     li.appendChild(taskRow);
     
-    // Add subtasks section
-    if (task.subtasks && task.subtasks.length > 0) {
+    // Add subtasks section (only when allowed)
+    if (showSubtasks && task.subtasks && task.subtasks.length > 0) {
         const subtaskCount = task.subtasks.length;
         const activeSubtasks = task.subtasks.filter(st => !st.completed).length;
         
@@ -217,13 +226,14 @@ export const createTaskElement = (task, level = 0, onCheckboxChange, onDelete, o
         // For each subtask, create a nested task element (with level+1)
         task.subtasks.forEach(subtask => {
             const subtaskElement = createTaskElement(
-                subtask, 
+                subtask,
                 level + 1,
                 onCheckboxChange,
                 onDelete,
                 onAddSubtask,
                 onToggleSticky,
-                onTaskClick
+                onTaskClick,
+                showSubtasks
             );
             subtaskList.appendChild(subtaskElement);
         });


### PR DESCRIPTION
## Summary
- hide subtasks when rendering top-level tasks
- add `showSubtasks` option to `createTaskElement`

## Testing
- `node --check www/assets/js/modules/ui.js`
- `node --check www/assets/js/modules/app.js`
