### PR TITLE
Fix JS cache busting

### DIFF
--- a/www/assets/js/main.js
+++ b/www/assets/js/main.js
@@ -4,7 +4,16 @@
  */
 import { init } from './modules/app.js';
 
-// Initialize the application when the DOM is ready
-document.addEventListener('DOMContentLoaded', () => {
+// Initialize the application when the DOM is ready. If the script is
+// injected after the DOMContentLoaded event has already fired, call
+// `init` immediately so the application still starts.
+function startApp() {
     init();
-});
+}
+
+if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', startApp);
+} else {
+    // DOM has already loaded, run immediately
+    startApp();
+}

--- a/www/index.html
+++ b/www/index.html
@@ -113,6 +113,19 @@
         </div>
         
     </div>
-    <script type="module" src="/assets/js/main.js?v=20250517"></script>
+    <script>
+        function loadMain(version) {
+            const script = document.createElement('script');
+            script.type = 'module';
+            script.src = `/assets/js/main.js?v=${version}`;
+            document.head.appendChild(script);
+        }
+
+        fetch('/assets/js/main.js', { method: 'HEAD', cache: 'no-cache' })
+            .then(r => r.headers.get('Last-Modified'))
+            .then(t => t ? new Date(t).getTime() : Date.now())
+            .then(loadMain)
+            .catch(() => loadMain(Date.now()));
+    </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- load `main.js` dynamically using the last modified time
- run `init()` even when the script loads after `DOMContentLoaded`

## Testing
- `git status --short`