### PR TITLE
Fix sharing focused subtask

### DIFF
--- a/www/api/index.php
+++ b/www/api/index.php
@@ -65,6 +65,7 @@ switch ($resource) {
                 $data = json_decode(file_get_contents('php://input'), true);
                 $share_id = generate_share_id();
                 $tasks = isset($data['tasks']) ? $data['tasks'] : [];
+                $focus_id = isset($data['focusId']) ? $data['focusId'] : null;
                 
                 $list_data = [
                     'id' => $share_id,
@@ -72,6 +73,9 @@ switch ($resource) {
                     'created' => date('c'),
                     'lastModified' => date('c')
                 ];
+                if ($focus_id) {
+                    $list_data['focusId'] = $focus_id;
+                }
                 
                 file_put_contents(get_task_file_path($share_id), json_encode($list_data));
                 echo json_encode(['shareId' => $share_id]);

--- a/www/assets/js/modules/storage.js
+++ b/www/assets/js/modules/storage.js
@@ -7,6 +7,7 @@ import { getCurrentDate } from './utils.js';
 // Storage state
 let isSharedList = false;
 let shareId = null;
+let shareFocusId = null;
 let activeDate = getCurrentDate();
 
 // Initialize the storage state based on URL parameters
@@ -15,6 +16,7 @@ export const initializeStorageState = () => {
     if (urlParams.has('share')) {
         shareId = urlParams.get('share');
         isSharedList = true;
+        shareFocusId = null;
         return { isSharedList, shareId };
     }
     return { isSharedList, shareId };
@@ -34,10 +36,14 @@ export const getIsSharedList = () => isSharedList;
 // Get the share ID
 export const getShareId = () => shareId;
 
+// Get the focus task ID for a shared list
+export const getShareFocusId = () => shareFocusId;
+
 // Set up for sharing (update state variables)
-export const setupSharing = (newShareId) => {
+export const setupSharing = (newShareId, focusId = null) => {
     shareId = newShareId;
     isSharedList = true;
+    shareFocusId = focusId;
 };
 
 // Get subscribed shared lists
@@ -111,6 +117,7 @@ export const loadTasksFromServer = async () => {
             throw new Error(`Server responded with ${response.status}: ${await response.text()}`);
         }
         const data = await response.json();
+        shareFocusId = data.focusId || null;
         return data.tasks || [];
     } catch (error) {
         console.error('Error loading shared tasks:', error);
@@ -142,7 +149,7 @@ export const saveTasksToServer = async (tasks) => {
 };
 
 // Create a shared list on the server
-export const createSharedList = async (tasks) => {
+export const createSharedList = async (tasks, focusId = null) => {
     try {
         console.log('Creating shared list with API endpoint: /api/lists');
         console.log('Tasks to be shared:', tasks);
@@ -152,7 +159,7 @@ export const createSharedList = async (tasks) => {
             headers: {
                 'Content-Type': 'application/json'
             },
-            body: JSON.stringify({ tasks })
+            body: JSON.stringify(focusId ? { tasks, focusId } : { tasks })
         });
         
         if (!response.ok) {


### PR DESCRIPTION
## Summary
- keep list focus internal instead of using a URL parameter
- store `focusId` with shared lists when creating them
- auto-focus when opening a shared list with a stored `focusId`

## Testing
- `git status --short`
