### PR TITLE
Improve share auto focus

### DIFF
--- a/www/api/index.php
+++ b/www/api/index.php
@@ -65,10 +65,12 @@ switch ($resource) {
                 $data = json_decode(file_get_contents('php://input'), true);
                 $share_id = generate_share_id();
                 $tasks = isset($data['tasks']) ? $data['tasks'] : [];
+                $focus_id = isset($data['focusId']) ? $data['focusId'] : null;
                 
                 $list_data = [
                     'id' => $share_id,
                     'tasks' => $tasks,
+                    'focusId' => $focus_id,
                     'created' => date('c'),
                     'lastModified' => date('c')
                 ];
@@ -100,9 +102,13 @@ switch ($resource) {
                     if (file_exists($file_path)) {
                         $data = json_decode(file_get_contents('php://input'), true);
                         $tasks = isset($data['tasks']) ? $data['tasks'] : [];
-                        
+                        $focus_id = isset($data['focusId']) ? $data['focusId'] : null;
+
                         $list_data = json_decode(file_get_contents($file_path), true);
                         $list_data['tasks'] = $tasks;
+                        if ($focus_id !== null) {
+                            $list_data['focusId'] = $focus_id;
+                        }
                         $list_data['lastModified'] = date('c');
                         
                         file_put_contents($file_path, json_encode($list_data));

--- a/www/assets/js/modules/storage.js
+++ b/www/assets/js/modules/storage.js
@@ -7,6 +7,7 @@ import { getCurrentDate } from './utils.js';
 // Storage state
 let isSharedList = false;
 let shareId = null;
+let sharedListFocusId = null;
 let activeDate = getCurrentDate();
 
 // Initialize the storage state based on URL parameters
@@ -15,6 +16,7 @@ export const initializeStorageState = () => {
     if (urlParams.has('share')) {
         shareId = urlParams.get('share');
         isSharedList = true;
+        sharedListFocusId = null;
         return { isSharedList, shareId };
     }
     return { isSharedList, shareId };
@@ -34,10 +36,14 @@ export const getIsSharedList = () => isSharedList;
 // Get the share ID
 export const getShareId = () => shareId;
 
+// Get the focus ID for a shared list
+export const getSharedListFocusId = () => sharedListFocusId;
+
 // Set up for sharing (update state variables)
 export const setupSharing = (newShareId) => {
     shareId = newShareId;
     isSharedList = true;
+    sharedListFocusId = null;
 };
 
 // Get subscribed shared lists
@@ -111,6 +117,7 @@ export const loadTasksFromServer = async () => {
             throw new Error(`Server responded with ${response.status}: ${await response.text()}`);
         }
         const data = await response.json();
+        sharedListFocusId = data.focusId || null;
         return data.tasks || [];
     } catch (error) {
         console.error('Error loading shared tasks:', error);
@@ -119,14 +126,14 @@ export const loadTasksFromServer = async () => {
 };
 
 // Save tasks to server
-export const saveTasksToServer = async (tasks) => {
+export const saveTasksToServer = async (tasks, focusId = null) => {
     try {
         const response = await fetch(`/api/lists/${shareId}`, {
             method: 'PUT',
             headers: {
                 'Content-Type': 'application/json'
             },
-            body: JSON.stringify({ tasks })
+            body: JSON.stringify(focusId ? { tasks, focusId } : { tasks })
         });
         
         if (!response.ok) {
@@ -142,7 +149,7 @@ export const saveTasksToServer = async (tasks) => {
 };
 
 // Create a shared list on the server
-export const createSharedList = async (tasks) => {
+export const createSharedList = async (tasks, focusId = null) => {
     try {
         console.log('Creating shared list with API endpoint: /api/lists');
         console.log('Tasks to be shared:', tasks);
@@ -152,7 +159,7 @@ export const createSharedList = async (tasks) => {
             headers: {
                 'Content-Type': 'application/json'
             },
-            body: JSON.stringify({ tasks })
+            body: JSON.stringify(focusId ? { tasks, focusId } : { tasks })
         });
         
         if (!response.ok) {
@@ -163,6 +170,7 @@ export const createSharedList = async (tasks) => {
         
         const data = await response.json();
         console.log('Share response:', data);
+        sharedListFocusId = focusId;
         return data.shareId;
     } catch (error) {
         console.error('Error creating shared list:', error);


### PR DESCRIPTION
## Summary
- extend API to persist focusId
- track shared list focus in storage
- create share links without `focus` parameter and auto-focus using saved id

## Testing
- `npm test` *(fails: Could not read package.json)*