### PR TITLE
Hide subscribe button when opening owned share

### DIFF
--- a/www/assets/js/modules/app.js
+++ b/www/assets/js/modules/app.js
@@ -50,10 +50,14 @@ export const init = async () => {
             ui.addSubscribedListsUI(subscribedLists, handleSubscribedListClick);
         }
     } else {
-        // Check if current shared list is already in subscriptions
-        const subscribedLists = storage.getSubscribedLists();
-        const isAlreadySubscribed = subscribedLists.some(list => list.id === shareId);
-        ui.updateSubscribeButtonState(isAlreadySubscribed);
+        if (storage.isOwnedList(shareId)) {
+            ui.hideSubscribeButton();
+        } else {
+            // Check if current shared list is already in subscriptions
+            const subscribedLists = storage.getSubscribedLists();
+            const isAlreadySubscribed = subscribedLists.some(list => list.id === shareId);
+            ui.updateSubscribeButtonState(isAlreadySubscribed);
+        }
     }
     
     // Render initial task list
@@ -211,6 +215,7 @@ const handleShareButtonClick = async () => {
             
             // Update app state
             storage.setupSharing(newShareId);
+            storage.addOwnedList(newShareId);
             ui.setupSharedUI();
             // Do not show the "Save to My Lists" button when creating a share
             ui.hideSubscribeButton();

--- a/www/assets/js/modules/storage.js
+++ b/www/assets/js/modules/storage.js
@@ -84,6 +84,30 @@ export const unsubscribeFromSharedList = (id) => {
     return updatedLists;
 };
 
+// ----- Owned shared lists helpers -----
+
+export const getOwnedLists = () => {
+    const lists = localStorage.getItem('todoOwnedLists');
+    return lists ? JSON.parse(lists) : [];
+};
+
+const saveOwnedLists = (lists) => {
+    localStorage.setItem('todoOwnedLists', JSON.stringify(lists));
+};
+
+export const addOwnedList = (id) => {
+    const lists = getOwnedLists();
+    if (!lists.includes(id)) {
+        lists.push(id);
+        saveOwnedLists(lists);
+    }
+};
+
+export const isOwnedList = (id) => {
+    const lists = getOwnedLists();
+    return lists.includes(id);
+};
+
 // Initialize storage
 export const initializeStorage = async () => {
     if (isSharedList) {

--- a/www/assets/js/modules/ui.js
+++ b/www/assets/js/modules/ui.js
@@ -2,7 +2,7 @@
  * UI-related functions for the Todo app
  */
 import { $, createSeparator } from './utils.js';
-import { getShareId, getIsSharedList } from './storage.js';
+import { getShareId, getIsSharedList, isOwnedList } from './storage.js';
 
 // DOM elements
 export const domElements = {
@@ -272,8 +272,12 @@ export const setupSharedUI = () => {
         domElements.currentDateDisplay.textContent = 'Shared List';
         domElements.currentDateDisplay.className = 'text-sm px-4 py-1 bg-gray-100 rounded-md'; // Add rounded corners when not between buttons
 
-        // Show subscribe button and back button
-        domElements.subscribeButton.classList.remove('hidden');
+        // Show back button and subscribe button only if not owner
+        if (!isOwnedList(getShareId())) {
+            domElements.subscribeButton.classList.remove('hidden');
+        } else {
+            domElements.subscribeButton.classList.add('hidden');
+        }
         domElements.backToPersonalButton.classList.remove('hidden');
     }
 };


### PR DESCRIPTION
## Summary
- track user's own shared lists in `localStorage`
- hide the subscribe button for shared lists that the current user owns
- store new shared list ids when creating shares

## Testing
- `node -c www/assets/js/modules/storage.js`
- `node -c www/assets/js/modules/app.js`
- `node -c www/assets/js/modules/ui.js`
