### PR TITLE
Fix owner share button visibility

### DIFF
--- a/www/assets/js/modules/app.js
+++ b/www/assets/js/modules/app.js
@@ -33,12 +33,13 @@ const handleToggleSticky = async (id) => {
 export const init = async () => {
     // Initialize storage state
     const { isSharedList, shareId } = storage.initializeStorageState();
+    const isOwner = isSharedList && storage.isOwnedList(shareId);
     
     // Initialize storage system
     await storage.initializeStorage();
     
     // Setup UI for shared list if needed
-    ui.setupSharedUI();
+    ui.setupSharedUI(isOwner);
     
     // Set up event listeners
     setupEventListeners();
@@ -50,7 +51,7 @@ export const init = async () => {
             ui.addSubscribedListsUI(subscribedLists, handleSubscribedListClick);
         }
     } else {
-        if (storage.isOwnedList(shareId)) {
+        if (isOwner) {
             ui.hideSubscribeButton();
         } else {
             // Check if current shared list is already in subscriptions
@@ -216,7 +217,7 @@ const handleShareButtonClick = async () => {
             // Update app state
             storage.setupSharing(newShareId);
             storage.addOwnedList(newShareId);
-            ui.setupSharedUI();
+            ui.setupSharedUI(true);
             // Do not show the "Save to My Lists" button when creating a share
             ui.hideSubscribeButton();
         } catch (error) {

--- a/www/assets/js/modules/ui.js
+++ b/www/assets/js/modules/ui.js
@@ -264,7 +264,7 @@ export const updateBreadcrumbTrail = (taskNavigationStack, onJumpToBreadcrumb) =
 };
 
 // Setup UI for shared list
-export const setupSharedUI = () => {
+export const setupSharedUI = (isOwner = isOwnedList(getShareId())) => {
     if (getIsSharedList()) {
         // Hide date navigation for shared lists - completely remove instead of just disabling
         domElements.prevDayButton.classList.add('hidden');
@@ -273,7 +273,7 @@ export const setupSharedUI = () => {
         domElements.currentDateDisplay.className = 'text-sm px-4 py-1 bg-gray-100 rounded-md'; // Add rounded corners when not between buttons
 
         // Show back button and subscribe button only if not owner
-        if (!isOwnedList(getShareId())) {
+        if (!isOwner) {
             domElements.subscribeButton.classList.remove('hidden');
         } else {
             domElements.subscribeButton.classList.add('hidden');


### PR DESCRIPTION
## Summary
- ensure subscribe button stays hidden when owners open their own shared link
- pass ownership flag to `setupSharedUI`

## Testing
- `git status --short`