### PR TITLE
Fix breadcrumb root action for owned shared lists

### DIFF
--- a/www/assets/js/modules/app.js
+++ b/www/assets/js/modules/app.js
@@ -248,7 +248,14 @@ const switchToDate = async (newDate) => {
 // Jump to a specific breadcrumb level
 const jumpToBreadcrumb = (index) => {
     if (index === 'root') {
-        // Go back to root level (all tasks)
+        // If we're the owner viewing a shared list, going to the root should
+        // return to the personal list which shows the date navigation.
+        if (storage.getIsSharedList() && storage.isOwnedList(storage.getShareId())) {
+            handleBackToPersonalList();
+            return;
+        }
+
+        // Otherwise, go back to the root level of the current list
         taskNavigationStack = [];
         currentFocusedTaskId = null;
         ui.domElements.taskBreadcrumb.classList.add('hidden');


### PR DESCRIPTION
## Summary
- when the owner of a shared list clicks the "All Tasks" breadcrumb, redirect to their personal list so date navigation appears

## Testing
- `node --check www/assets/js/modules/app.js`
- `for f in www/assets/js/modules/*.js; do node --check $f; done`