### PR TITLE
Enable realtime shared list updates via SSE

### DIFF
--- a/www/api/updates.php
+++ b/www/api/updates.php
@@ -1,0 +1,47 @@
+<?php
+// Simple Server-Sent Events endpoint for real-time updates
+header('Content-Type: text/event-stream');
+header('Cache-Control: no-cache');
+header('Connection: keep-alive');
+
+// Ensure script doesn't timeout
+set_time_limit(0);
+
+// Get share ID
+$shareId = isset($_GET['share']) ? $_GET['share'] : null;
+if (!$shareId) {
+    http_response_code(400);
+    echo "data: {\"error\":\"Share ID required\"}\n\n";
+    flush();
+    exit;
+}
+
+// Data directory and file path
+$dataDir = __DIR__ . '/data';
+$filepath = $dataDir . '/' . $shareId . '.json';
+if (!file_exists($filepath)) {
+    http_response_code(404);
+    echo "data: {\"error\":\"List not found\"}\n\n";
+    flush();
+    exit;
+}
+
+$lastModified = filemtime($filepath);
+
+// Keep connection open and send updates when file changes
+while (true) {
+    if (connection_aborted()) {
+        break;
+    }
+    clearstatcache(false, $filepath);
+    $currentModified = filemtime($filepath);
+    if ($currentModified !== $lastModified) {
+        $lastModified = $currentModified;
+        $data = file_get_contents($filepath);
+        echo "data: $data\n\n";
+        ob_flush();
+        flush();
+    }
+    sleep(2);
+}
+?>

--- a/www/assets/js/modules/app.js
+++ b/www/assets/js/modules/app.js
@@ -64,6 +64,13 @@ export const init = async () => {
     // Render initial task list
     await renderTasks();
 
+    // Real-time updates for shared lists
+    if (isSharedList) {
+        storage.connectToUpdates(() => {
+            renderTasks();
+        });
+    }
+
     // Auto focus on shared list's saved focus task
     const focusId = storage.getSharedListFocusId();
     if (focusId) {
@@ -113,6 +120,7 @@ const handleSubscribeButtonClick = async () => {
 // Handle returning to personal list from shared list
 const handleBackToPersonalList = () => {
     // Clear the share parameter from URL and reload
+    storage.disconnectUpdates();
     const url = new URL(window.location.href);
     url.searchParams.delete('share');
     window.location.href = url.href;

--- a/www/assets/js/modules/storage.js
+++ b/www/assets/js/modules/storage.js
@@ -294,3 +294,30 @@ export const saveTasks = async (tasks) => {
         localStorage.setItem('todoStickyTasks', JSON.stringify(stickyTasks));
     }
 };
+
+// ----- Real-time updates via Server-Sent Events -----
+let sseSource = null;
+
+export const connectToUpdates = (onUpdate) => {
+    if (!isSharedList || !shareId) return;
+    if (sseSource) {
+        sseSource.close();
+    }
+    sseSource = new EventSource(`/api/updates.php?share=${shareId}`);
+    sseSource.onmessage = (event) => {
+        if (!event.data) return;
+        try {
+            const data = JSON.parse(event.data);
+            if (onUpdate) onUpdate(data);
+        } catch (err) {
+            console.error('Failed to parse update', err);
+        }
+    };
+};
+
+export const disconnectUpdates = () => {
+    if (sseSource) {
+        sseSource.close();
+        sseSource = null;
+    }
+};


### PR DESCRIPTION
## Summary
- add a simple Server‑Sent Events endpoint
- connect to SSE from the app when viewing a shared list
- stop SSE updates when leaving a shared list

## Testing
- `node -v`
