### PR TITLE
Add dark mode toggle

### DIFF
--- a/www/assets/css/todo.css
+++ b/www/assets/css/todo.css
@@ -41,3 +41,17 @@
 .drag-over {
     background-color: #e0f2fe;
 }
+/* Dark mode overrides */
+html.dark body {
+    background-color: #111827;
+    color: #e5e7eb;
+}
+html.dark .dark\:bg-gray-700 { background-color: #374151 !important; }
+html.dark .dark\:bg-gray-800 { background-color: #1f2937 !important; }
+html.dark .dark\:bg-gray-600 { background-color: #4b5563 !important; }
+html.dark .dark\:hover\:bg-gray-600:hover { background-color: #4b5563 !important; }
+html.dark .dark\:hover\:bg-gray-500:hover { background-color: #6b7280 !important; }
+html.dark .dark\:text-gray-200 { color: #e5e7eb !important; }
+html.dark .dark\:text-gray-300 { color: #d1d5db !important; }
+html.dark .dark\:text-gray-400 { color: #9ca3af !important; }
+html.dark .dark\:text-gray-500 { color: #6b7280 !important; }

--- a/www/assets/js/main.js
+++ b/www/assets/js/main.js
@@ -3,11 +3,17 @@
  * Imports the modular components and initializes the app
  */
 import { init } from './modules/app.js';
+import { initializeTheme, toggleTheme } from './modules/theme.js';
 
 // Initialize the application when the DOM is ready. If the script is
 // injected after the DOMContentLoaded event has already fired, call
 // `init` immediately so the application still starts.
 function startApp() {
+    initializeTheme();
+    const toggleButton = document.getElementById('theme-toggle');
+    if (toggleButton) {
+        toggleButton.addEventListener('click', toggleTheme);
+    }
     init();
 }
 

--- a/www/assets/js/modules/theme.js
+++ b/www/assets/js/modules/theme.js
@@ -1,0 +1,23 @@
+const STORAGE_KEY = 'theme';
+
+function applyTheme(theme) {
+    const root = document.documentElement;
+    if (theme === 'dark') {
+        root.classList.add('dark');
+    } else {
+        root.classList.remove('dark');
+    }
+}
+
+export function toggleTheme() {
+    const current = localStorage.getItem(STORAGE_KEY) === 'dark' ? 'dark' : 'light';
+    const next = current === 'dark' ? 'light' : 'dark';
+    localStorage.setItem(STORAGE_KEY, next);
+    applyTheme(next);
+}
+
+export function initializeTheme() {
+    const saved = localStorage.getItem(STORAGE_KEY);
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    applyTheme(saved ? saved : (prefersDark ? 'dark' : 'light'));
+}

--- a/www/index.html
+++ b/www/index.html
@@ -11,14 +11,14 @@
     <!-- Minimal styles without animations -->
     <link rel="stylesheet" href="/assets/css/todo.css">
 </head>
-<body class="bg-gray-50 text-gray-800 min-h-screen">
+<body class="bg-gray-50 text-gray-800 min-h-screen dark:bg-gray-900 dark:text-gray-200">
     <div class="container mx-auto px-4 py-6 max-w-lg">
         <header class="text-center mb-6">
-            <h1 class="text-3xl font-bold text-gray-700">Todo</h1>
+            <h1 class="text-3xl font-bold text-gray-700 dark:text-gray-200">Todo</h1>
             <div class="flex items-center justify-center mt-3">
-                <button id="prev-day" class="text-sm bg-gray-100 hover:bg-gray-200 px-3 py-1 rounded-l-md">&larr; Prev</button>
-                <div id="current-date" class="text-sm px-4 py-1 bg-gray-100">Today</div>
-                <button id="next-day" class="text-sm bg-gray-100 hover:bg-gray-200 px-3 py-1 rounded-r-md">Next &rarr;</button>
+                <button id="prev-day" class="text-sm bg-gray-100 hover:bg-gray-200 px-3 py-1 rounded-l-md dark:bg-gray-700 dark:hover:bg-gray-600 dark:text-gray-200">&larr; Prev</button>
+                <div id="current-date" class="text-sm px-4 py-1 bg-gray-100 dark:bg-gray-700 dark:text-gray-200">Today</div>
+                <button id="next-day" class="text-sm bg-gray-100 hover:bg-gray-200 px-3 py-1 rounded-r-md dark:bg-gray-700 dark:hover:bg-gray-600 dark:text-gray-200">Next &rarr;</button>
             </div>
             <div class="mt-3 flex flex-col gap-2">
                 <!-- Back to My List button (only shown for shared lists) -->
@@ -35,10 +35,13 @@
                     </svg>
                     Share List
                 </button>
-                <div id="share-url-container" class="hidden mt-2 bg-gray-100 p-2 rounded-md max-w-md mx-auto">
+                <button id="theme-toggle" class="text-sm bg-gray-100 hover:bg-gray-200 px-4 py-1 rounded-md mx-auto dark:bg-gray-700 dark:hover:bg-gray-600 dark:text-gray-200">
+                    Toggle Dark Mode
+                </button>
+                <div id="share-url-container" class="hidden mt-2 bg-gray-100 p-2 rounded-md max-w-md mx-auto dark:bg-gray-800">
                     <div class="flex items-center">
-                        <input id="share-url" type="text" readonly class="bg-white px-2 py-1 rounded text-sm flex-grow mr-2" />
-                        <button id="copy-share-url" class="text-sm bg-gray-300 hover:bg-gray-400 px-2 py-1 rounded">
+                        <input id="share-url" type="text" readonly class="bg-white px-2 py-1 rounded text-sm flex-grow mr-2 dark:bg-gray-800 dark:text-gray-200" />
+                        <button id="copy-share-url" class="text-sm bg-gray-300 hover:bg-gray-400 px-2 py-1 rounded dark:bg-gray-600 dark:hover:bg-gray-500 dark:text-gray-200">
                             Copy
                         </button>
                     </div>
@@ -63,7 +66,7 @@
             <div id="focus-title" class="text-lg font-semibold"></div>
         </div>
         
-        <div class="bg-white rounded-lg shadow-md p-6">
+        <div class="bg-white rounded-lg shadow-md p-6 dark:bg-gray-800">
             <!-- Add task form -->
             <form id="task-form" class="flex items-center mb-6">
                 <input 
@@ -85,7 +88,7 @@
             <div id="tasks-container">
                 <!-- Active tasks -->
                 <div class="flex justify-end items-center mb-4">
-                    <span id="task-count" class="text-sm text-gray-500">0 tasks</span>
+                    <span id="task-count" class="text-sm text-gray-500 dark:text-gray-400">0 tasks</span>
                 </div>
                 
                 <ul id="active-task-list" class="space-y-2 mb-6">
@@ -94,15 +97,15 @@
                 
                 <!-- Empty state for active tasks -->
                 <div id="empty-state" class="text-center py-6">
-                    <p class="text-gray-500">Your task list is empty</p>
-                    <p class="text-sm text-gray-400 mt-1">Add a task to get started</p>
+                    <p class="text-gray-500 dark:text-gray-400">Your task list is empty</p>
+                    <p class="text-sm text-gray-400 dark:text-gray-500 mt-1">Add a task to get started</p>
                 </div>
                 
                 <!-- Completed tasks section -->
                 <div id="completed-section" class="mt-8 pt-6 border-t border-gray-200" style="display: none;">
                     <div class="flex justify-between items-center mb-4">
-                        <h2 class="text-lg font-medium text-gray-600">Completed</h2>
-                        <span id="completed-count" class="text-sm text-gray-500">0 completed</span>
+                        <h2 class="text-lg font-medium text-gray-600 dark:text-gray-300">Completed</h2>
+                        <span id="completed-count" class="text-sm text-gray-500 dark:text-gray-400">0 completed</span>
                     </div>
                     
                     <ul id="completed-task-list" class="space-y-2">


### PR DESCRIPTION
## Summary
- implement a new theme module with localStorage support
- load theme at startup and add a toggle button handler
- style page elements for dark mode
- include dark theme CSS overrides

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest` *(fails: command not found)*