### PR TITLE
Automatic shared list subscription

### DIFF
--- a/www/assets/js/modules/ui.js
+++ b/www/assets/js/modules/ui.js
@@ -272,12 +272,8 @@ export const setupSharedUI = (isOwner = isOwnedList(getShareId())) => {
         domElements.currentDateDisplay.textContent = '';
         domElements.currentDateDisplay.className = 'hidden';
 
-        // Show subscribe button only if not owner
-        if (!isOwner) {
-            domElements.subscribeButton.classList.remove('hidden');
-        } else {
-            domElements.subscribeButton.classList.add('hidden');
-        }
+        // The subscribe button is no longer shown in shared view
+        domElements.subscribeButton.classList.add('hidden');
 
         // Show button to return to personal lists
         domElements.backToPersonalButton.classList.remove('hidden');


### PR DESCRIPTION
## Summary
- auto-subscribe when visiting a shared link and hide the button
- always fetch user lists on init
- remove Subscribe button from shared list UI

## Testing
- `git status --short`