### PR TITLE
Remove manual subscribe UI

### DIFF
--- a/www/assets/js/modules/ui.js
+++ b/www/assets/js/modules/ui.js
@@ -23,8 +23,6 @@ export const domElements = {
     shareUrlContainer: $('share-url-container'),
     shareUrlInput: $('share-url'),
     copyShareUrlButton: $('copy-share-url'),
-    subscribeButton: $('subscribe-button'),
-    subscribeText: $('subscribe-text'),
     backToPersonalButton: $('back-to-personal-button')
 };
 
@@ -272,29 +270,8 @@ export const setupSharedUI = (isOwner = isOwnedList(getShareId())) => {
         domElements.currentDateDisplay.textContent = '';
         domElements.currentDateDisplay.className = 'hidden';
 
-        // The subscribe button is no longer shown in shared view
-        domElements.subscribeButton.classList.add('hidden');
-
         // Show button to return to personal lists
         domElements.backToPersonalButton.classList.remove('hidden');
-    }
-};
-
-// Hide the subscribe button
-export const hideSubscribeButton = () => {
-    domElements.subscribeButton.classList.add('hidden');
-};
-
-// Update subscribe button state based on whether the list is already subscribed
-export const updateSubscribeButtonState = (isSubscribed) => {
-    if (isSubscribed) {
-        domElements.subscribeText.textContent = 'Remove from My Lists';
-        domElements.subscribeButton.classList.remove('bg-green-500', 'hover:bg-green-600');
-        domElements.subscribeButton.classList.add('bg-red-500', 'hover:bg-red-600');
-    } else {
-        domElements.subscribeText.textContent = 'Save to My Lists';
-        domElements.subscribeButton.classList.remove('bg-red-500', 'hover:bg-red-600');
-        domElements.subscribeButton.classList.add('bg-green-500', 'hover:bg-green-600');
     }
 };
 

--- a/www/index.html
+++ b/www/index.html
@@ -50,13 +50,6 @@
                     </div>
                 </div>
                 
-                <!-- Save to My Lists button (only shown for shared lists) -->
-                <button id="subscribe-button" class="hidden text-sm bg-green-500 hover:bg-green-600 text-white px-4 py-1 rounded-md flex items-center mx-auto">
-                    <svg class="h-4 w-4 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z"></path>
-                    </svg>
-                    <span id="subscribe-text">Save to My Lists</span>
-                </button>
             </div>
         </header>
         


### PR DESCRIPTION
## Summary
- auto-subscribe viewers of shared lists
- drop subscribe button and associated JS logic
- show subscribed lists in personal view with ability to remove

## Testing
- `git status --short`